### PR TITLE
Remove unused variables in material

### DIFF
--- a/src/material.c
+++ b/src/material.c
@@ -43,8 +43,6 @@ int read_material(struct material *material) {
     extern int current_operation;
     extern char current_target[2048];
     FILE *f;
-    int i;
-    int success;
     char actual_path[2048];
     char rapified_path[2048];
 


### PR DESCRIPTION
Fixes the following warnings when compiling armake (compiler: mingw32-make on Windows Bash).

```
src/material.c: In function 'read_material':
src/material.c:47:9: warning: unused variable 'success' [-Wunused-variable]
     int success;
         ^
src/material.c:46:9: warning: unused variable 'i' [-Wunused-variable]
     int i;
         ^
```
