### PR TITLE
check the return value of lzo_init()

### DIFF
--- a/src/img2paa.c
+++ b/src/img2paa.c
@@ -292,7 +292,10 @@ int img2paa(char *source, char *target) {
 
             memcpy(tmp, outputdata, datalen);
 
-            lzo_init();
+            if (lzo_init() != LZO_E_OK) {
+                errorf("Failed to initialize LZO for compression.\n");
+                return 6;
+	    }
             if (lzo1x_1_compress(tmp, in_len, outputdata, &out_len, workmem) != LZO_E_OK) {
                 errorf("Failed to compress image data.\n");
                 return 6;

--- a/src/paa2img.c
+++ b/src/paa2img.c
@@ -318,7 +318,10 @@ int paa2img(char *source, char *target) {
 
     if (compression == COMP_LZO) {
         out_len = imgdatalen;
-        lzo_init();
+        if (lzo_init() != LZO_E_OK) {
+            errorf("Failed to initialize LZO for decompression.\n");
+            return 3;
+	}
         if (lzo1x_decompress(compresseddata, datalen, imgdata, &out_len, NULL) != LZO_E_OK) {
             errorf("Failed to decompress LZO data.\n");
             return 3;


### PR DESCRIPTION
make sure the return value of lzo_init() is LZO_E_OK

currently just returning same error codes as for compression(6)/decompression(3) errors