### PR TITLE
Fix rap/derap of += array operator

### DIFF
--- a/src/derapify.c
+++ b/src/derapify.c
@@ -788,9 +788,6 @@ int derapify_class(FILE *f_source, FILE *f_target, char *classname, int level) {
             }
             fputs(";\n", f_target);
         } else if (type == 2 || type == 5) {
-            if (type == 5)
-                fseek(f_source, 4, SEEK_CUR);
-
             fp_tmp = ftell(f_source);
             fgets(buffer, sizeof(buffer), f_source);
             fseek(f_source, fp_tmp + strlen(buffer) + 1, SEEK_SET);

--- a/src/rapify.c
+++ b/src/rapify.c
@@ -572,7 +572,7 @@ int rapify_class(FILE *f_source, FILE *f_target, struct lineref *lineref, int le
 
         fputc((char)type, f_target);
 
-        if (type == 2) {
+        if (type == 2 || type == 5) {
             fwrite(word, strlen(word) + 1, 1, f_target);
 
             success = rapify_array(f_source, f_target, lineref);


### PR DESCRIPTION
## Aim of PR
This PR fixes the faulty behavior for the `+=` array operator during both rap and derap.

## Description of current behavior
The current behavior does not allow the following actions on a file with an `+=` array operator in it.

Example File `CfgFile.cpp`:
```
class CfgLoadouts {
    class CommonBlufor {
       items[] += {"ACE_fieldDressing", 4, "ACE_packingBandage", 4, "ACE_elasticBandage", 4, "ACE_quikclot", 4, "ACE_morphine", "ACE_earplugs"};
    };
};
```



```
armake binarize CfgFile.cpp CfgFile1.cpp
armake derapify CfgFile1.cpp CfgFile2.cpp
```

While `CfgFile1.hpp` will be created, armake will not rapify the array following the `+=` operator as the following snippet from the file read within a python shell shows:
```
items\x00{"ACE_fieldDressing", 4, "ACE_packingBandage", 4, "ACE_elasticBandage", 4, "ACE_quikclot", 4, "ACE_morphine", "ACE_earplugs"}
```

Therefore `armake derapify` is not able to read the array correctly, resulting in an error claiming the according array as `unknown type 34`.

## Description of fix

The fix is rather easy. It allows both `type 2` (array) and `type 5` (array with +=) to be rapified.
The second part of the fix is to skip the `fseek()` command as otherwise the first 4 characters of the array variable will be skipped (e.g. `s[] += {...` instead of `items[] += {...`)