### PR TITLE
Build with position independent code (force PIC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC = src
 LIB = lib
 EXT =
 CC = gcc
-CFLAGS = -Wall -Wno-misleading-indentation -DVERSION=\"v$(VERSION)\" -std=gnu89 -ggdb
+CFLAGS = -Wall -Wno-misleading-indentation -DVERSION=\"v$(VERSION)\" -std=gnu89 -fPIC -ggdb
 CLIBS = -I$(LIB) -lm -lcrypto
 
 $(BIN)/armake: \


### PR DESCRIPTION
Arch moved to Position Independent Codea few months ago. Improves security or something. Anyways, this will let us build armake on distros that use PIC (such as Arch).