### PR TITLE
Use RAND_poll() for OpenSSL 1.1.0+

### DIFF
--- a/src/keygen.c
+++ b/src/keygen.c
@@ -109,6 +109,11 @@ int generate_keypair(char *name, char *path_private, char *path_public) {
     exponent = BN_bin2bn((unsigned char *)&exponent_be, sizeof(exponent_be), NULL);
 
     // seed PRNG
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    do {
+        RAND_poll();
+    } while (RAND_status() != 1);
+#else
 #ifdef _WIN32
     do {
         RAND_screen();
@@ -123,6 +128,7 @@ int generate_keypair(char *name, char *path_private, char *path_public) {
         RAND_seed(rand_buffer, sizeof(rand_buffer));
     } while (RAND_status() != 1);
     fclose(f_random);
+#endif
 #endif
 
     // generate keypair


### PR DESCRIPTION
`RAND_poll()` replaces `RAND_screen()` (now deprecated) in OpenSSL 1.1.0.
https://ylvpn.yonyou.com/prx/000/https/www.openssl.org/docs/manmaster/man3/RAND_screen.html:
> RAND_event() and RAND_screen() are equivalent to RAND_poll().
> RAND_event() and RAND_screen() were deprecated in OpenSSL 1.1.0 and should not be used.

Additionally `RAND_screen()` was for Windows only and  `RAND_poll()` seems to be available for both.
https://www.openssl.org/docs/man1.0.2/crypto/RAND_add.html:
> The RAND_screen() function is available for the convenience of Windows programmers.