### PR TITLE
Fix wrong logging function call in model_config.c

### DIFF
--- a/src/model_config.c
+++ b/src/model_config.c
@@ -148,7 +148,7 @@ int read_animations(FILE *f, char *config_path, struct skeleton *skeleton) {
         } else if (strcmp(value, "hide") == 0) {
             skeleton->animations[j].type = TYPE_HIDE;
         } else {
-            warningf(current_target, -1, "Unknown animation type: %s\n", value);
+            lwarningf(current_target, -1, "Unknown animation type: %s\n", value);
             continue;
         }
 

--- a/src/rapify.c
+++ b/src/rapify.c
@@ -441,7 +441,7 @@ int rapify_file(char *source, char *target) {
             errorf("Failed to get temp file name (system error %i).\n", GetLastError());
             return 1;
         }
-        f_target = fopen(temp_name, "wb+");
+        f_target = fopen(temp_name2, "wb+");
 #else
         f_target = tmpfile();
 #endif


### PR DESCRIPTION
It was passing the file path to `warningf` as the format parameter.
Instead of passing the file path to `lwarningf` as the file parameter.

Found that problem while making `current_target` a `const char*` which it should always have been.