### PR TITLE
Performance optimization in rapify

### DIFF
--- a/src/rapify.c
+++ b/src/rapify.c
@@ -279,7 +279,7 @@ void rapify_class(struct class *class, FILE *f_target) {
             fp_temp = ftell(f_target);
             fseek(f_target, ((struct class *)(tmp->content))->offset_location, SEEK_SET);
             fwrite(&fp_temp, sizeof(uint32_t), 1, f_target);
-            fseek(f_target, 0, SEEK_END);
+            fseek(f_target, fp_temp, SEEK_SET);
 
             rapify_class(tmp->content, f_target);
         }


### PR DESCRIPTION
It's a rather trivial change. 
Instead of letting it search for EOF everytime to seek till there. We already know that EOF is at fp_temp, so just directly seek there instead of searching for EOF.

~I found the problem when profiling my C++ port.~
~Before:~
~Binarize of AIO config: 1.849s~
~Time spent in seekp: 32.6%~

~After:~
~Binarize: 1.46s~
~Time spent in seekp: 18.5%~

~The code used to profile this is using `_fseeki64`. But I can imagine that the effect will be the same with `fseek`~

Nvm. The difference showed up the first two profiler runs. And then it didn't anymore. Probably doesn't matter.
I still prefer the looks of it tho.