### PR TITLE
Fix handling \" as escaped quote

### DIFF
--- a/src/rapify.l
+++ b/src/rapify.l
@@ -91,7 +91,7 @@ bool tmp;
     return T_STRING;
 }
 
-\"(\\.|\"\"|[^"])*\"    {
+\"(\"\"|[^"])*\?"    {
     RESET_VARS;
     yylval.string_value = (char *)safe_malloc(yyleng + 1);
     strcpy(yylval.string_value, yytext);
@@ -99,7 +99,7 @@ bool tmp;
     return T_STRING;
 }
 
-'(\\.|''|[^'])*' {
+'(''|[^'])*?' {
     RESET_VARS;
     yylval.string_value = (char *)safe_malloc(yyleng + 1);
     strcpy(yylval.string_value, yytext);

--- a/src/rapify.l
+++ b/src/rapify.l
@@ -91,7 +91,7 @@ bool tmp;
     return T_STRING;
 }
 
-\"(\"\"|[^"])*\?"    {
+\"(\"\"|[^"])*?\"    {
     RESET_VARS;
     yylval.string_value = (char *)safe_malloc(yyleng + 1);
     strcpy(yylval.string_value, yytext);


### PR DESCRIPTION
Config parser would error on things like
`entry = "string\path\to\something\";` with an error about a missing ending quote.
Because it thinks the \ is escaping the quotes.
\ is not a escape character in Arma configs though. Quotes are escaped by placing two next to eachother.