### PR TITLE
Fix buffer overflow on large arrays

### DIFF
--- a/src/rapify.l
+++ b/src/rapify.l
@@ -107,7 +107,7 @@ bool tmp;
     return T_STRING;
 }
 
-[^;{"' \t\n][^;{\n]*/[ \t\n]*; {
+[^;,{"' \t\n][^;{\n]*/[ \t\n]*; {
     if (!allow_val)
         REJECT;
 


### PR DESCRIPTION
Fixes #89

On large arrays of strings (see attachment in https://github.com/KoffeinFlummi/armake/issues/89#issuecomment-440254713) the parser would see the `,` that it should parse now as a T_COMMA token. But because the parser has to choose the longest matching pattern, and one of the "unquoted string" patterns doesn't error after the first character being a comma, it tries to match the full "unquoted string" pattern and runs out of space in the buffer before it reaches the end of the array.

buffer size is hardcoded to be 
8kb(32bit)/16kb(64bit) or
16kb(32bit)/32kb(64bit) depending on which version of flex is being used.
Arma vanilla config has a array of  `supporters` in the credits config that is 39kb big, thus running out of buffer space on any kind of buffer size that you can get.