### PR TITLE
Fix max bones limit

### DIFF
--- a/src/model_config.h
+++ b/src/model_config.h
@@ -19,7 +19,7 @@
 #pragma once
 
 
-#define MAXBONES 512
+#define MAXBONES 255
 #define MAXSECTIONS 1024
 #define MAXANIMS 1024
 


### PR DESCRIPTION
Mikero, Mondkalb and reyhard just confirmed in Arma discord that the engine bone limit is 255.
There is no reason for armake to support more than what the Arma engine can support.

Armake would ideally print a warning if a user approaches the bone limit. I don't do that in this PR.

Btw this reduces memory usage for a skeleton by about 260KB.